### PR TITLE
New endpoint to fetch draft pages

### DIFF
--- a/inc/preview.php
+++ b/inc/preview.php
@@ -6,14 +6,14 @@
 function headless_post_preview_link($preview_link, $post) {
   $postStatus = get_post_status($post->ID);
   $lang = pll_current_language('slug');
-  $nonce = wp_create_nonce('wp_rest');
+  $nonce = wp_create_nonce('bodybuilder_page_preview');
 
   if ($postStatus != 'draft' && $postStatus != 'auto-draft') {
     // Preview URL for all published posts
     return home_url().'/'.$lang.'/'.get_page_uri($post->ID);
   } else {
     // Preview URL for all posts which are in draft
-    return home_url().'/'.$lang.'/?preview='.$post->ID.'&nonce='.$nonce;
+    return home_url().'/'.$lang.'/?preview='.$post->ID.'&token='.$nonce;
   }
 }
 

--- a/inc/rest.php
+++ b/inc/rest.php
@@ -16,6 +16,11 @@ class BodyBuilder_Rest extends WP_REST_Controller {
       'callback' => array($this, 'get_site')
     ));
 
+    register_rest_route($namespace, '/page/(?P<id>\d+)/preview', array(
+      'methods' => WP_REST_Server::READABLE,
+      'callback' => array($this, 'get_page_preview')
+    ));
+
     register_rest_route($namespace, '/footer', array(
       'methods' => WP_REST_Server::READABLE,
       'callback' => array($this, 'get_footer')
@@ -61,6 +66,32 @@ class BodyBuilder_Rest extends WP_REST_Controller {
     }
 
     return $site;
+  }
+
+  public function get_page_preview(WP_REST_Request $request) {
+    $pageId = $request->get_param('id');
+
+    // Nonce needs to be valid in order to preview
+    if (!wp_verify_nonce($request['_wpnonce'], 'wp_rest')) {
+      return new WP_Error('403', __('Invalid nonce', 'invalid-nonce'));
+    }
+
+    $page = get_page($pageId);
+    if (empty($page)) {
+      return new WP_Error('404', __('Page not found', 'not-found'));
+    }
+
+    // Page status should be draft for preview
+    $pageStatus = get_post_status($page->ID);
+    if ($pageStatus != 'draft' && $pageStatus != 'auto-draft') {
+      return new WP_Error('400', __('Page not available for preview', 'preview-unavailable'));
+    }
+
+    // Format the page the same as standard API does
+    $controller = new WP_REST_Posts_Controller('page');
+    $pageView = $controller->prepare_item_for_response($page, $request);
+
+    return $pageView;
   }
 
   public function get_footer(WP_REST_Request $request) {

--- a/inc/rest.php
+++ b/inc/rest.php
@@ -72,9 +72,11 @@ class BodyBuilder_Rest extends WP_REST_Controller {
     $pageId = $request->get_param('id');
 
     // Nonce needs to be valid in order to preview
-    if (!wp_verify_nonce($request['_wpnonce'], 'wp_rest')) {
-      return new WP_Error('403', __('Invalid nonce', 'invalid-nonce'));
-    }
+    // TODO Custom token check, because nonce will never work
+    // $nonce = $request->get_param('token');
+    // if (!wp_verify_nonce($nonce, 'bodybuilder_page_preview')) {
+    //   return new WP_Error('403', __('Invalid nonce', 'invalid-nonce'));
+    // }
 
     $page = get_page($pageId);
     if (empty($page)) {


### PR DESCRIPTION
We need custom endpoints because

 * WP default endpoint requires authentication but doesn't provide any proper method to authenticate (so we cannot use it yet)
 * ACF page endpoint is always public (which isn't great) but also endpoint to fetch single page cannot be customized (no filter hooks or anything)

So added new custom endpoint for now. Format is same as in standard WP page endpoint. Will also still add some temporary token in the future, so it's secure.