### PR TITLE
Renamed footer to settings

### DIFF
--- a/inc/rest.php
+++ b/inc/rest.php
@@ -21,9 +21,9 @@ class BodyBuilder_Rest extends WP_REST_Controller {
       'callback' => array($this, 'get_page_preview')
     ));
 
-    register_rest_route($namespace, '/footer', array(
+    register_rest_route($namespace, '/settings', array(
       'methods' => WP_REST_Server::READABLE,
-      'callback' => array($this, 'get_footer')
+      'callback' => array($this, 'get_settings')
     ));
   }
 
@@ -53,7 +53,7 @@ class BodyBuilder_Rest extends WP_REST_Controller {
 
     $site = new stdClass();
     $site->menu = $this->get_menu($request);
-    $site->footer = $this->get_footer($request);
+    $site->settings = $this->get_settings($request);
 
     // Get the homepage ID set via settings
     $homepageId = get_option('page_on_front');
@@ -96,24 +96,24 @@ class BodyBuilder_Rest extends WP_REST_Controller {
     return $pageView;
   }
 
-  public function get_footer(WP_REST_Request $request) {
+  public function get_settings(WP_REST_Request $request) {
     $lang = substr($request->get_header('Accept-Language'), 0, 2);
-    $footer = new stdClass();
+    $settings = new stdClass();
 
     if ($lang === 'en') {
-      $footer->columns = get_field('footer_columns', 'english');
-      $footer->social_media = get_field('social_media', 'english');
+      $settings->footer = get_field('footer_columns', 'english');
+      $settings->social_media = get_field('social_media', 'english');
     }
     else {
-      $footer->columns = get_field('footer_columns', 'suomi');
-      $footer->social_media = get_field('social_media', 'suomi');
+      $settings->footer = get_field('footer_columns', 'suomi');
+      $settings->social_media = get_field('social_media', 'suomi');
     }
 
-    if (empty($footer)) {
+    if (empty($settings)) {
       return new WP_Error('500', __('Footer not found', 'not-found'));
     }
 
-    return $footer;
+    return $settings;
   }
 }
 


### PR DESCRIPTION
Footer has been renamed to 'settings', so the `/site` response is now slightly different and footer handling on the frontend should be changed.

Settings object has 2 properties

 - 'footer' which is an array and has column objects in it
 - 'social_media' which has the social media stuff to be used in the header